### PR TITLE
Jenkins can't allocate a TTY, so remove the -t flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ${ROOTFS_TAR}: mkdebootstrap
 	@# run chroot as part of debootstrap
 	docker run \
 		--name $(BUILDER_NAME) \
-		-it \
+		-i \
 		--privileged \
 		--volume /var/$(DEBIAN_SUITE) \
 		$(BUILDER_ID) \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ ${ROOTFS_TAR}: mkdebootstrap
 	@# run chroot as part of debootstrap
 	docker run \
 		--name $(BUILDER_NAME) \
-		-i \
 		--privileged \
 		--volume /var/$(DEBIAN_SUITE) \
 		$(BUILDER_ID) \


### PR DESCRIPTION
@raggi Jenkins can't allocate a TTY for `docker run`, so I removed the `-t` flag, ran a test build on this branch, and verified that it worked.