### PR TITLE
Switch over to the reproducible debian images by default.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ then
   export TAG
 fi
 
-CONFIG=cloudbuild.yaml
+CONFIG=reproducible/cloudbuild.yaml
 
 while test $# -gt 0; do
   case "$1" in
@@ -70,7 +70,4 @@ else
   usage
 fi
 
-cp -R third_party/docker/mkimage* mkdebootstrap/
-
-envsubst < mkdebootstrap/Dockerfile.in > mkdebootstrap/Dockerfile
-gcloud container builds submit . --config="$CONFIG" --verbosity=info --substitutions=_REPO="$REPO",_TAG="$TAG",_VERSION="$VERSION",_VERSION_NUMBER="$VERSION_NUMBER"
+gcloud container builds submit . --config="$CONFIG" --verbosity=info --substitutions=_REPO="$REPO",_TAG="$TAG",_VERSION_NUMBER="$VERSION_NUMBER"

--- a/reproducible/cloudbuild.yaml
+++ b/reproducible/cloudbuild.yaml
@@ -6,10 +6,10 @@ steps:
   # We have to build and load the builder image first, so it can be used in the next step.
   # Using "run" instead of "build" loads the built image into the daemon.
   - name: gcr.io/cloud-builders/bazel
-    args: ['run', '//reproducible:debian8']
+    args: ['run', '//reproducible:debian${_VERSION_NUMBER}']
   
   # Give the image the right tag, and let CloudBuild push it.
   - name: gcr.io/cloud-builders/docker
-    args: ['tag', 'bazel/reproducible:debian8', 'gcr.io/$PROJECT_ID/debtest:latest']
+    args: ['tag', 'bazel/reproducible:debian${_VERSION_NUMBER}', '${_REPO}/debian${_VERSION_NUMBER}:${_TAG}']
 
-images: ['gcr.io/$PROJECT_ID/debtest:latest']
+images: ['${_REPO}/debian${_VERSION_NUMBER}:${_TAG}']


### PR DESCRIPTION
This makes the reproducible/cloudbuild.yaml take the same parameters as the existing cloudbuild.yaml, and switches our build script to call that by default.