### PR TITLE
Add PATH and CMDs.

### DIFF
--- a/reproducible/BUILD
+++ b/reproducible/BUILD
@@ -33,24 +33,29 @@ pkg_tar(
 
 load("//reproducible:debootstrap.bzl", "debootstrap_image")
 
+DEBIAN_ENV = {
+    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "PORT": "8080",
+}
+
 debootstrap_image(
     name = "debian8",
     distro = "jessie",
-    env = {"PORT": "8080"},
+    env = DEBIAN_ENV,
     overlay_tar = ":overlay.tar",
 )
 
 debootstrap_image(
     name = "debian9",
     distro = "stretch",
-    env = {"PORT": "8080"},
+    env = DEBIAN_ENV,
     overlay_tar = ":overlay.tar",
 )
 
 debootstrap_image(
     name = "debian10",
     distro = "buster",
-    env = {"PORT": "8080"},
+    env = DEBIAN_ENV,
     overlay_tar = ":overlay.tar",
 )
 

--- a/reproducible/debootstrap.bzl
+++ b/reproducible/debootstrap.bzl
@@ -98,4 +98,5 @@ def debootstrap_image(name, variant="minbase", distro="jessie", overlay_tar="", 
         name=name,
         tars=tars,
         env=env,
+        cmd="/bin/bash",
     )


### PR DESCRIPTION
The image had the correct path set, but I'm not really sure
where it came from. Maybe a default in docker run? There was already
a test.

The image didn't have a CMD set though, and I can't tell where that
was coming from in the old image. It's not in the Dockerfile. Maybe
a default in docker build? We don't currently have a way to test this,
I'll open an issue in structure test to add one.